### PR TITLE
skip empty sequences

### DIFF
--- a/server.js
+++ b/server.js
@@ -99,7 +99,7 @@ function lines(result) {
   let look = ['red', 0.7]
   while (older > first) {
     let seq = events.filter(event => event.timestamp >= older && event.timestamp < older+interval)
-    runs.push(draw(seq, ...look))
+    if(seq.length) runs.push(draw(seq, ...look))
     older -= interval
     look = ['gray', 0.1]
   }

--- a/server.js
+++ b/server.js
@@ -62,7 +62,7 @@ function log(query, result) {
 }
 
 function svg(result) {
-  console.log('nrql guid', result.metadata.guid, 'query time', result.performanceStats.wallClockTime)
+  console.log('nrql guid', result.metadata.guid, 'query time', result.performanceStats.wallClockTime, 'event count', result.results[0].events.length)
   return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     <svg viewBox="0 0 600 300" style="background-color:white"
         xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Recent changes to eldorado-et has it producing event sequences that break our draw code. We now skip them.